### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ import 'package:flutter_clean_architecture/flutter_clean_architecture.dart';
 class CounterPage extends View {
     @override
      // Dependencies can be injected here
-     State<StatefulWidget> createState() => CounterState(CounterState());
+     State<StatefulWidget> createState() => CounterState(CounterController());
 }
 
 class CounterState extends ViewState<CounterPage, CounterController> {


### PR DESCRIPTION
Just a fix for #11 
I know it might not look like much but people learning Flutter and Clean Architecture at the same time (like me) would be really confused.

Thanks for the awesome package