### PR TITLE
Controller onResumed: assertion failed context != null #28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.2] - Thursday, December 26th, 2019
+
+* Fixed an issue where `Controller.getContext()` throws due to losing context because lifecycle events where triggered after the `View` had already been dismounted.
+
 ## [2.0.1] - Thursday, December 26th, 2019
 
 * Fixed error in docs
@@ -6,7 +10,7 @@
 
 * Updated RxDart dependency
 * Breaking changes
-** All Observable return types are now changed to Streams
+  * All Observable return types are now changed to Streams
 * Updated documentation
 
 ## [1.1.0] - Tuesday, December 17th, 2019

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add this to your package's pubspec.yaml file:
 ```yaml
 
 dependencies:
-  flutter_clean_architecture: ^2.0.1
+  flutter_clean_architecture: ^2.0.2
 
 ```
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -75,7 +75,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.1"
+    version: "2.0.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -79,32 +79,35 @@ import 'package:meta/meta.dart';
 abstract class Controller with WidgetsBindingObserver, RouteAware {
   Function _refresh; // callback function for refreshing the UI
   bool isLoading; // indicates whether a loading dialog is present
-  bool _isMounted = true;
+  bool _isMounted;
   Logger logger;
   GlobalKey<State<StatefulWidget>> _globalKey;
 
   @mustCallSuper
   Controller() {
     logger = Logger('${this.runtimeType}');
+    _isMounted = true;
     isLoading = false;
     initListeners();
   }
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    switch (state) {
-      case AppLifecycleState.inactive:
-        onInActive();
-        break;
-      case AppLifecycleState.paused:
-        onPaused();
-        break;
-      case AppLifecycleState.resumed:
-        onResumed();
-        break;
-      case AppLifecycleState.detached:
-        onDetached();
-        break;
+    if (_isMounted) {
+      switch (state) {
+        case AppLifecycleState.inactive:
+          onInActive();
+          break;
+        case AppLifecycleState.paused:
+          onPaused();
+          break;
+        case AppLifecycleState.resumed:
+          onResumed();
+          break;
+        case AppLifecycleState.detached:
+          onDetached();
+          break;
+      }
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_clean_architecture
 description: A Flutter package that implements the Clean Architecture by Uncle Bob in Flutter. It provides Views, Controllers, Presenters, Observers, and UseCases.
-version: 2.0.1
+version: 2.0.2
 author: Shady Boukhary <sb199898.sb@gmail.com>
 homepage: https://github.com/ShadyBoukhary/flutter_clean_architecture
 


### PR DESCRIPTION


## Description
Fixes issue #28, where context is lost within the Controller upon `onResumed()` due to lifecycle events sometimes being triggered after the `View` has already been dismounted from the tree.

## Developer checklist

- [x] All steps on circleci are passing.

## For reviewers

All PR's needs at least one reviewer to be merged.

Before merge this PR confirm that it meets all requirements listed below:

- The PR has good quality code and has tests (if is the case)
- This PR is not checked with WIP on title