### PR TITLE
Use Provider package to improve performance of View-Controller interactions #18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.0.0] - Wednesday, January 8th, 2020
+
+
 ## [2.0.2] - Thursday, December 26th, 2019
 
 * Fixed an issue where `Controller.getContext()` throws due to losing context because lifecycle events where triggered after the `View` had already been dismounted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## [3.0.0] - Wednesday, January 8th, 2020
+### What's New
+- Improves performance of the library by using the [Provider package](https://pub.dev/packages/provider) internally.
+- Added an option to enable debug mode via `FlutterCleanArchitecture.debugModeOn()`
+- Added the ability to use a common `Controller` for widgets that exist within a page.
+The widgets can access the `Controller` in the tree via the `FlutterCleanArchitecture.getController<Controller>(context)` method.
 
+### Breaking Changes
+- `ViewState`'s `build()` method can no longer be overridden.
+- `ViewState` UI code must now go into `buildPage()` method.
+- `callHandler()` is now removed
+- Removed `loadOnStart()`
+- Removed `startLoading()`
+- Removed `dismissLoading()`
 
 ## [2.0.2] - Thursday, December 26th, 2019
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_clean_architecture/flutter_clean_architecture.dart';
+
 import './src/app/pages/home/home_view.dart';
 import 'package:flutter/material.dart';
 
@@ -7,6 +9,7 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
+    FlutterCleanArchitecture.debugModeOn();
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(

--- a/example/lib/src/app/pages/home/home_controller.dart
+++ b/example/lib/src/app/pages/home/home_controller.dart
@@ -42,6 +42,13 @@ class HomeController extends Controller {
 
   void buttonPressed() {
     _counter++;
+    refreshUI();
+  }
+
+  @override
+  void onResumed() {
+    print("On resumed");
+    super.onResumed();
   }
 
   @override

--- a/example/lib/src/app/pages/home/home_view.dart
+++ b/example/lib/src/app/pages/home/home_view.dart
@@ -63,8 +63,7 @@ class _HomePageState extends ViewState<HomePage, HomeController> {
         ),
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () => controller
-            .buttonPressed(), // callhandler refreshes the view the handler has finished
+        onPressed: () => controller.buttonPressed(),
         tooltip: 'Increment',
         child: Icon(Icons.add),
       ), // This trailing comma makes auto-formatting nicer for build methods.

--- a/example/lib/src/app/pages/home/home_view.dart
+++ b/example/lib/src/app/pages/home/home_view.dart
@@ -12,14 +12,14 @@ class HomePage extends View {
   @override
   _HomePageState createState() =>
       // inject dependencies inwards
-      _HomePageState(HomeController(DataUsersRepository()));
+      _HomePageState();
 }
 
 class _HomePageState extends ViewState<HomePage, HomeController> {
-  _HomePageState(HomeController controller) : super(controller);
+  _HomePageState() : super(HomeController(DataUsersRepository()));
 
   @override
-  Widget build(BuildContext context) {
+  Widget buildPage() {
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
@@ -63,8 +63,8 @@ class _HomePageState extends ViewState<HomePage, HomeController> {
         ),
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () => callHandler(controller
-            .buttonPressed), // callhandler refreshes the view the handler has finished
+        onPressed: () => controller
+            .buttonPressed(), // callhandler refreshes the view the handler has finished
         tooltip: 'Increment',
         child: Icon(Icons.add),
       ), // This trailing comma makes auto-formatting nicer for build methods.

--- a/example/lib/src/app/widgets/button.dart
+++ b/example/lib/src/app/widgets/button.dart
@@ -1,4 +1,4 @@
-import 'package:example/src/app/pages/home/home_controller.dart';
+import '../pages/home/home_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_clean_architecture/flutter_clean_architecture.dart';
 
@@ -9,7 +9,8 @@ class HomePageButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // use a common controller assuming HomePageButton is always a child of Home
-    HomeController controller = FlutterCleanArchitecture.getController<HomeController>(context);
+    HomeController controller =
+        FlutterCleanArchitecture.getController<HomeController>(context);
     return GestureDetector(
       onTap: controller.buttonPressed,
       child: Container(

--- a/example/lib/src/app/widgets/button.dart
+++ b/example/lib/src/app/widgets/button.dart
@@ -1,0 +1,33 @@
+import 'package:example/src/app/pages/home/home_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_clean_architecture/flutter_clean_architecture.dart';
+
+class HomePageButton extends StatelessWidget {
+  final String text;
+  HomePageButton({@required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    // use a common controller assuming HomePageButton is always a child of Home
+    HomeController controller = FlutterCleanArchitecture.getController<HomeController>(context);
+    return GestureDetector(
+      onTap: controller.buttonPressed,
+      child: Container(
+        height: 50.0,
+        alignment: FractionalOffset.center,
+        decoration: BoxDecoration(
+          color: Color.fromRGBO(230, 38, 39, 1.0),
+          borderRadius: BorderRadius.circular(25.0),
+        ),
+        child: Text(
+          text,
+          style: const TextStyle(
+              color: Colors.white,
+              fontSize: 20.0,
+              fontWeight: FontWeight.w300,
+              letterSpacing: 0.4),
+        ),
+      ),
+    );
+  }
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -75,7 +75,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.2"
+    version: "3.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -109,6 +109,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.8"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4"
   path:
     dependency: transitive
     description:
@@ -130,6 +137,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.4.0"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.1"
   quiver:
     dependency: transitive
     description:
@@ -214,3 +228,4 @@ packages:
     version: "3.5.0"
 sdks:
   dart: ">=2.6.0 <3.0.0"
+  flutter: ">=1.12.1"

--- a/lib/flutter_clean_architecture.dart
+++ b/lib/flutter_clean_architecture.dart
@@ -1,6 +1,8 @@
 library flutter_clean_architecture;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_clean_architecture/src/controller.dart';
+import 'package:logging/logging.dart';
 import 'package:provider/provider.dart';
 
 export 'package:flutter_clean_architecture/src/controller.dart';
@@ -10,11 +12,24 @@ export 'package:flutter_clean_architecture/src/usecase.dart';
 export 'package:flutter_clean_architecture/src/view.dart';
 export 'package:flutter_clean_architecture/src/background_usecase.dart';
 
-
 class FlutterCleanArchitecture {
   /// Retrieves a Controller from the widget tree if one exists
   /// Can be used in widgets that exist in pages and need to use the same controller
   static Con getController<Con extends Controller>(BuildContext context) {
     return Provider.of<Con>(context);
   }
+
+  static void debugModeOn() {
+    Logger.root.level = Level.ALL;
+    Logger.root.onRecord.listen((record) {
+      dynamic e = record.error;
+      print('${record.loggerName}: ${record.level.name}: ${record.message} ');
+      if (e != null) {
+        print(e.toString());
+      }
+    });
+
+    Logger.root.info("Logger initialized.");
+  }
+
 }

--- a/lib/flutter_clean_architecture.dart
+++ b/lib/flutter_clean_architecture.dart
@@ -31,5 +31,4 @@ class FlutterCleanArchitecture {
 
     Logger.root.info("Logger initialized.");
   }
-
 }

--- a/lib/flutter_clean_architecture.dart
+++ b/lib/flutter_clean_architecture.dart
@@ -19,6 +19,7 @@ class FlutterCleanArchitecture {
     return Provider.of<Con>(context);
   }
 
+  /// Enables logging inside the `FlutterCleanArchitecture` package,
   static void debugModeOn() {
     Logger.root.level = Level.ALL;
     Logger.root.onRecord.listen((record) {

--- a/lib/flutter_clean_architecture.dart
+++ b/lib/flutter_clean_architecture.dart
@@ -1,4 +1,7 @@
 library flutter_clean_architecture;
+import 'package:flutter/material.dart';
+import 'package:flutter_clean_architecture/src/controller.dart';
+import 'package:provider/provider.dart';
 
 export 'package:flutter_clean_architecture/src/controller.dart';
 export 'package:flutter_clean_architecture/src/observer.dart';
@@ -6,3 +9,12 @@ export 'package:flutter_clean_architecture/src/presenter.dart';
 export 'package:flutter_clean_architecture/src/usecase.dart';
 export 'package:flutter_clean_architecture/src/view.dart';
 export 'package:flutter_clean_architecture/src/background_usecase.dart';
+
+
+class FlutterCleanArchitecture {
+  /// Retrieves a Controller from the widget tree if one exists
+  /// Can be used in widgets that exist in pages and need to use the same controller
+  static Con getController<Con extends Controller>(BuildContext context) {
+    return Provider.of<Con>(context);
+  }
+}

--- a/lib/src/background_usecase.dart
+++ b/lib/src/background_usecase.dart
@@ -116,6 +116,7 @@ abstract class BackgroundUseCase<T, Params> extends UseCase<T, Params> {
               BackgroundUseCaseParams(_receivePort.sendPort, params: params))
           .then<void>((Isolate isolate) {
         if (!isRunning) {
+          logger.info('Killing background isolate.');
           isolate.kill(priority: Isolate.immediate);
         } else {
           _state = BackgroundUseCaseState.calculating;
@@ -144,6 +145,7 @@ abstract class BackgroundUseCase<T, Params> extends UseCase<T, Params> {
     if (isRunning) {
       _state = BackgroundUseCaseState.idle;
       if (_isolate != null) {
+        logger.info('Killing background isolate.');
         _isolate.kill(priority: Isolate.immediate);
         _isolate = null;
       }

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -63,11 +63,7 @@ import 'package:meta/meta.dart';
 ///                   // show the number of times the button has been clicked
 ///                   child: Text(controller.counter.toString()),
 ///                 ),
-///                 // wrapping the controller.increment with callHandler() automatically
-///                 // refreshes the state after the counter is incremented
-///                 // you can also refresh manually inside the controller
-///                 // using refreshUI()
-///                 MaterialButton(onPressed: () => callHandler(controller.increment)),
+///                 MaterialButton(onPressed: () => controller.increment()),
 ///               ],
 ///             ),
 ///           ),

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -78,7 +78,6 @@ import 'package:meta/meta.dart';
 /// ```
 abstract class Controller
     with WidgetsBindingObserver, RouteAware, ChangeNotifier {
-  bool isLoading; // indicates whether a loading dialog is present
   bool _isMounted;
   Logger logger;
   GlobalKey<State<StatefulWidget>> _globalKey;
@@ -87,7 +86,6 @@ abstract class Controller
   Controller() {
     logger = Logger('${this.runtimeType}');
     _isMounted = true;
-    isLoading = false;
     initListeners();
   }
 
@@ -109,32 +107,6 @@ abstract class Controller
           break;
       }
     }
-  }
-
-  /// Dismisses the loading dialog. The parent `View` of this [Controller] should have its body wrapped
-  /// in the ModelHUD and is listening to the [Controller]'s [isLoading]. Otherwise, this method will
-  /// have no impact.
-  @protected
-  void dismissLoading() {
-    isLoading = false;
-    refreshUI();
-  }
-
-  /// Sets the loading to true. The `View` body should be wrapped in a loader.
-  /// Call on initial page load. For example, if a loader is needed as soon as you open a page.
-  /// Only works when called inside the [Controller] constructor.
-  @protected
-  void loadOnStart() {
-    isLoading = true;
-  }
-
-  /// Sets the loading to true. The `View` body should be wrapped in a loader.
-  /// Call when a loader is needed after an event (e.g. a button press).
-  /// Does not work if called inside the [Controller] constructor.
-  @protected
-  void showLoading() {
-    isLoading = true;
-    refreshUI();
   }
 
   /// _refreshes the [View] associated with the [Controller] if it is still mounted.

--- a/lib/src/usecase.dart
+++ b/lib/src/usecase.dart
@@ -122,6 +122,7 @@ abstract class UseCase<T, Params> {
   /// Disposes (unsubscribes) from the [Stream]
   void dispose() {
     if (!_disposables.isDisposed) {
+      logger.info('Disposing $runtimeType');
       _disposables.dispose();
     }
   }

--- a/lib/src/view.dart
+++ b/lib/src/view.dart
@@ -29,11 +29,9 @@ import 'package:provider/provider.dart';
 ///                   // show the number of times the button has been clicked
 ///                   child: Text(controller.counter.toString()),
 ///                 ),
-///                 // wrapping the controller.increment with callHandler() automatically
-///                 // refreshes the state after the counter is incremented
-///                 // you can also refresh manually inside the controller
+///                 // you can refresh manually inside the controller
 ///                 // using refreshUI()
-///                 MaterialButton(onPressed: () => callHandler(controller.increment)),
+///                 MaterialButton(onPressed: controller.increment),
 ///               ],
 ///             ),
 ///           ),
@@ -44,7 +42,7 @@ import 'package:provider/provider.dart';
 /// ```
 abstract class ViewState<Page extends View, Con extends Controller>
     extends State<Page> {
-      
+
   final GlobalKey<State<StatefulWidget>> globalKey =
       GlobalKey<State<StatefulWidget>>();
   Con _controller;

--- a/lib/src/view.dart
+++ b/lib/src/view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_clean_architecture/src/controller.dart';
+import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:provider/provider.dart';
 
@@ -43,19 +44,23 @@ import 'package:provider/provider.dart';
 /// ```
 abstract class ViewState<Page extends View, Con extends Controller>
     extends State<Page> {
+      
   final GlobalKey<State<StatefulWidget>> globalKey =
       GlobalKey<State<StatefulWidget>>();
   Con _controller;
+  Logger _logger;
   Con get controller => _controller;
   ViewState(this._controller) {
     _controller.initController(globalKey);
     WidgetsBinding.instance.addObserver(_controller);
+    _logger = Logger('${this.runtimeType}');
   }
 
   @override
   @mustCallSuper
   void didChangeDependencies() {
     if (widget.routeObserver != null) {
+      _logger.info('$runtimeType is observring route events.');
       widget.routeObserver.subscribe(_controller, ModalRoute.of(context));
     }
 
@@ -78,7 +83,7 @@ abstract class ViewState<Page extends View, Con extends Controller>
   @override
   @mustCallSuper
   void dispose() {
-    //controller.dispose();
+    _logger.info('Disposing $runtimeType.');
     super.dispose();
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -193,6 +193,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4"
   node_preamble:
     dependency: transitive
     description:
@@ -242,6 +249,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.0"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.1"
   pub_semver:
     dependency: transitive
     description:
@@ -417,3 +431,4 @@ packages:
     version: "2.1.15"
 sdks:
   dart: ">=2.6.0 <3.0.0"
+  flutter: ">=1.12.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   meta: ^1.1.6
   rxdart: ^0.23.1
   logging: ^0.11.3+2
+  provider: ^4.0.1
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_clean_architecture
 description: A Flutter package that implements the Clean Architecture by Uncle Bob in Flutter. It provides Views, Controllers, Presenters, Observers, and UseCases.
-version: 2.0.2
+version: 3.0.0
 author: Shady Boukhary <sb199898.sb@gmail.com>
 homepage: https://github.com/ShadyBoukhary/flutter_clean_architecture
 

--- a/test/controller_test.dart
+++ b/test/controller_test.dart
@@ -3,7 +3,9 @@ import 'package:flutter/src/widgets/framework.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_clean_architecture/flutter_clean_architecture.dart';
 
-CounterController controller = CounterController();
+GlobalKey snackBar = GlobalKey();
+GlobalKey inc = GlobalKey();
+
 void main() {
   testWidgets('Controller can change data and refresh View',
       (WidgetTester tester) async {
@@ -15,20 +17,21 @@ void main() {
     Finder counterFinder = find.text('0');
     expect(counterFinder, findsOneWidget);
 
-    await tester.tap(find.byType(MaterialButton));
+    await tester.tap(find.byKey(inc));
     await tester.pump();
 
     expect(counterFinder, findsNothing);
     counterFinder = find.text('1');
     expect(counterFinder, findsOneWidget);
 
-    await tester.tap(find.byType(MaterialButton));
+    await tester.tap(find.byKey(inc));
     await tester.pump();
 
     expect(counterFinder, findsNothing);
     counterFinder = find.text('2');
     expect(counterFinder, findsOneWidget);
-    controller.showSnackBar();
+
+    await tester.tap(find.byKey(snackBar));
     await tester.pump();
     expect(find.text('Hi'), findsOneWidget);
   });
@@ -56,14 +59,14 @@ class CounterController extends Controller {
 
 class CounterPage extends View {
   @override
-  State<StatefulWidget> createState() => CounterState(controller);
+  State<StatefulWidget> createState() => CounterState();
 }
 
 class CounterState extends ViewState<CounterPage, CounterController> {
-  CounterState(CounterController controller) : super(controller);
+  CounterState() : super(CounterController());
 
   @override
-  Widget build(BuildContext context) {
+  Widget buildPage() {
     return MaterialApp(
       title: 'Flutter Demo',
       home: Scaffold(
@@ -73,7 +76,9 @@ class CounterState extends ViewState<CounterPage, CounterController> {
             Center(
               child: Text(controller.counter.toString()),
             ),
-            MaterialButton(onPressed: () => callHandler(controller.increment)),
+            MaterialButton(key: inc, onPressed: () => controller.increment()),
+            MaterialButton(
+                key: snackBar, onPressed: () => controller.showSnackBar()),
           ],
         ),
       ),


### PR DESCRIPTION
## Description

Improves upon the package according to #18 

### Breaking Changes
- `ViewState`'s `build()` method can no longer be overridden.
- `ViewState` UI code must now go into `buildPage()` method.
- `callHandler()` is now removed
- Removed `loadOnStart()`
- Removed `startLoading()`
- Removed `dismissLoading()`

## Developer checklist

- [x] All steps on circleci are passing.
- [x] Add ability to use a common Controller for a page and its child widgets
- [x] Update documentation


## For reviewers

All PR's needs at least one reviewer to be merged.

Before merge this PR confirm that it meets all requirements listed below:

- The PR has good quality code and has tests (if is the case)
- This PR is not checked with WIP on title