### PR TITLE
fix: Controller onResumed: assertion failed context != null

### DIFF
--- a/lib/src/view.dart
+++ b/lib/src/view.dart
@@ -82,6 +82,7 @@ abstract class ViewState<Page extends View, Con extends Controller>
   @mustCallSuper
   void dispose() {
     _logger.info('Disposing $runtimeType.');
+    _controller.dispose();
     super.dispose();
   }
 }


### PR DESCRIPTION
## Description
`_controller.dispose()` under View `dispose()`. This is to ensure that currentContext is updated always when `onResumed()` is ran 

Issue Reference: [https://github.com/ShadyBoukhary/flutter_clean_architecture/issues/33](https://github.com/ShadyBoukhary/flutter_clean_architecture/issues/33)