### PR TITLE
View lifecycle control improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [4.0.3] - Thursday, December 10th, 2020
+- Fixed `didChangeViewDependencies` to trigger correctly on `didChangeDependencies`
+
 ## [4.0.2] - Monday, October 5th, 2020
 - Updated example android build requirements for flutter 1.22
 - Created `didChangeViewDependencies` on `ViewState` to enable access to controller on `didChangeDependencies`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [4.0.4] - Thursday, December 17th, 2020
+- Removed `BuildContext` injection from `Controller.onDisposed` life cycle to avoid unsafe usages of dead context
+- Created `Controller.onInitState` to correct control `View.initState` life cycle.
+- Created `Controller.onDidChangeDependencies` to correct control `View.initState` life cycle.
+- Created `Controller.onDeactivated` to correct control `View.deactivate` life cycle.
+- Created `Controller.onReassembled` to correct control `View.reassemble` life cycle.
+- Deprecated `View.didChangeViewDependencies`. Added `Controller.didChangeDependencies` to ensure correct usage. 
+- Deprecated `View.initViewState`. Added `Controller.initState` to ensure correct usage. 
+
 ## [4.0.3] - Thursday, December 10th, 2020
 - Fixed `didChangeViewDependencies` to trigger correctly on `didChangeDependencies`
 - Deprecated `Controller.dispose`. Added `Controller.onDisposed` to ensure correct usage of `BuildContext` on dispose life cycle.

--- a/example/lib/src/app/pages/home/home_controller.dart
+++ b/example/lib/src/app/pages/home/home_controller.dart
@@ -46,10 +46,13 @@ class HomeController extends Controller {
   }
 
   @override
-  void onResumed() {
-    print('On resumed');
-    super.onResumed();
-  }
+  void onResumed() => print('On resumed');
+
+  @override
+  void onReassembled() => print('View is about to be reassembled');
+
+  @override
+  void onDeactivated() => print('View is about to be deactivated');
 
   @override
   void onDisposed() {

--- a/example/lib/src/app/pages/home/home_controller.dart
+++ b/example/lib/src/app/pages/home/home_controller.dart
@@ -52,8 +52,8 @@ class HomeController extends Controller {
   }
 
   @override
-  void onDisposed(BuildContext context) {
+  void onDisposed() {
     homePresenter.dispose(); // don't forget to dispose of the presenter
-    super.onDisposed(context);
+    super.onDisposed();
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.0.2"
+    version: "4.0.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.0.1"
+    version: "4.0.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -130,9 +130,8 @@ abstract class Controller
     assert(_globalKey.currentContext == null,
         '''Make sure you are not calling `dispose` in any other call. This method should only be called from view `dispose` method.
         
-        Also, the usage of context `onDispose` lifecycle is unsafe and it may lead to errors. If you need to remove any resouces from the
-        tree, please check if `onDeactivate`/`onActivate` lifecycles, that controls `deactivate`/`activate` view state are enough to 
-        your case
+        Also, the usage of context `onDispose` lifecycle is unsafe and it may lead to errors. If you need to remove any resources from the
+        tree, please check if `onDeactivate` lifecycle, that controls `deactivate` view state are enough to your case.
         
         For example:
         If this does not resolve for you, please open an issue at `https://github.com/ShadyBoukhary/flutter_clean_architecture` describing 
@@ -278,6 +277,73 @@ abstract class Controller
   ///     }
   /// ```
   void onDetached() {}
+
+  /// Called before the view is deactivated.
+  /// When the view is in this context, it means that the view is about to be extracted from the widget tree, but it can may be
+  /// added again. Quoting the view `deactivate` docs from `https://api.flutter.dev/flutter/widgets/State/deactivate.html`:
+  ///
+  /// ```The framework calls this method whenever it removes this State object from the tree.
+  ///   In some cases, the framework will reinsert the State object into another part of the tree
+  ///   (e.g., if the subtree containing this State object is grafted from one location in the tree to another).
+  ///   If that happens, the framework will ensure that it calls build to give the
+  ///   State object a chance to adapt to its new location in the tree.
+  /// ```
+  ///
+  /// So, this may be the correct lifecycle to remove any resources that depends on other widgets on widget tree.
+  ///
+  /// Usage:
+  ///
+  /// ```dart
+  ///     class MyController extends Controller {
+  ///       @override
+  ///       void onDeactivated() => print('View is about to be deactivated and maybe disposed');
+  ///     }
+  /// ```
+  void onDeactivated() {}
+
+  /// Called before the view is reassembled.
+  /// When this method is called on view life cycle on `reassemble`, and it guarantees that `build` lifecycle will
+  /// be called. Quoting the docs:
+  ///
+  /// ```Most widgets therefore do not need to do anything in the [reassemble] method.```
+  ///
+  /// Please be sure to read docs before use this life cycle.
+  ///
+  /// Usage:
+  ///
+  /// ```dart
+  ///     class MyController extends Controller {
+  ///       @override
+  ///       void onReassembled() => print('View is about to be reassembled');
+  ///     }
+  /// ```
+  void onReassembled() {}
+
+  /// Called before [View.didChangeDependencies] is called
+  ///
+  /// Should be used when need to perform some action on [View.didChangeDependencies] life cycle.
+  /// [View.initViewState] should be called before the actions you need to perform. Like [didChangeDependencies], you can safely perform
+  /// actions that depends on [BuildContext] here.
+  ///
+  /// ```dart
+  ///     class MyController extends Controller {
+  ///       @override
+  ///       void onDidChangeDependencies() => print('View is about to run didChangeDependencies life cycle');
+  ///     }
+  /// ```
+  void onDidChangeDependencies() {}
+
+  /// Called before [View.initState] is called
+  ///
+  /// Should be used when need to perform some action on [View.initState] life cycle.
+  ///
+  /// ```dart
+  ///     class MyController extends Controller {
+  ///       @override
+  ///       void onInitState() => print('View is about to run initState life cycle');
+  ///     }
+  /// ```
+  void onInitState() {}
 }
 
 typedef ControlledBuilder<Con extends Controller> = Widget Function(

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -245,6 +245,7 @@ abstract class Controller
   ///       void onInActive() => print('App is in the background.');
   ///     }
   /// ```
+  @visibleForOverriding
   void onInActive() {}
 
   /// Called when the application is not currently visible to the user, not responding to user input, and running in the background.
@@ -256,6 +257,7 @@ abstract class Controller
   ///       void onPaused() => print('App is paused.');
   ///     }
   /// ```
+  @visibleForOverriding
   void onPaused() {}
 
   /// Called when the application is visible and is responding to the user i.e. in the foreground and running.
@@ -265,6 +267,7 @@ abstract class Controller
   ///       void onResumed() => print('App is resumed.');
   ///     }
   /// ```
+  @visibleForOverriding
   void onResumed() {}
 
   /// Called before the application is detached.
@@ -276,6 +279,7 @@ abstract class Controller
   ///       void onDetached() => print('App is about to detach.');
   ///     }
   /// ```
+  @visibleForOverriding
   void onDetached() {}
 
   /// Called before the view is deactivated.
@@ -299,6 +303,7 @@ abstract class Controller
   ///       void onDeactivated() => print('View is about to be deactivated and maybe disposed');
   ///     }
   /// ```
+  @visibleForOverriding
   void onDeactivated() {}
 
   /// Called before the view is reassembled.
@@ -317,6 +322,7 @@ abstract class Controller
   ///       void onReassembled() => print('View is about to be reassembled');
   ///     }
   /// ```
+  @visibleForOverriding
   void onReassembled() {}
 
   /// Called before [View.didChangeDependencies] is called
@@ -331,6 +337,7 @@ abstract class Controller
   ///       void onDidChangeDependencies() => print('View is about to run didChangeDependencies life cycle');
   ///     }
   /// ```
+  @visibleForOverriding
   void onDidChangeDependencies() {}
 
   /// Called before [View.initState] is called
@@ -343,6 +350,7 @@ abstract class Controller
   ///       void onInitState() => print('View is about to run initState life cycle');
   ///     }
   /// ```
+  @visibleForOverriding
   void onInitState() {}
 }
 

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -126,11 +126,16 @@ abstract class Controller
 
   @mustCallSuper
   @visibleForOverriding
-  void onDisposed(BuildContext context) {
+  void onDisposed() {
     assert(_globalKey.currentContext == null,
-        '''Make sure you are not calling `disposeController` in any other call. This method should only be called from view `dispose` method.
+        '''Make sure you are not calling `dispose` in any other call. This method should only be called from view `dispose` method.
+        
+        Also, the usage of context `onDispose` lifecycle is unsafe and it may lead to errors. If you need to remove any resouces from the
+        tree, please check if `onDeactivate`/`onActivate` lifecycles, that controls `deactivate`/`activate` view state are enough to 
+        your case
+        
         For example:
-        If this is being triggered in any other way, please open an issue at `https://github.com/ShadyBoukhary/flutter_clean_architecture` describing 
+        If this does not resolve for you, please open an issue at `https://github.com/ShadyBoukhary/flutter_clean_architecture` describing 
      the error.''');
     dispose();
   }

--- a/lib/src/view.dart
+++ b/lib/src/view.dart
@@ -145,7 +145,8 @@ abstract class ViewState<Page extends View, Con extends Controller>
   }
 
   @mustCallSuper
-  @Deprecated('''To attribute the correct responsabilities to each class, all view lifecycles must be controlled by 
+  @Deprecated(
+      '''To attribute the correct responsabilities to each class, all view lifecycles must be controlled by 
     correct `Controller`.
     
     To achieve correct use of `ViewState.initState`, please check out `Controller.onInitState` method.
@@ -155,7 +156,8 @@ abstract class ViewState<Page extends View, Con extends Controller>
   void initViewState(Con controller) {}
 
   @mustCallSuper
-  @Deprecated('''To attribute the correct responsabilities to each class, all view lifecycles must be controlled by 
+  @Deprecated(
+      '''To attribute the correct responsabilities to each class, all view lifecycles must be controlled by 
     correct `Controller`.
     
     To achieve correct use of `ViewState.didChangeDependencies`, please check out `Controller.onDidChangeDependencies` method.
@@ -198,7 +200,8 @@ abstract class ViewState<Page extends View, Con extends Controller>
   @override
   @mustCallSuper
   void deactivate() {
-    _logger.info('Deactivating $runtimeType. (This is usually called right before dispose)');
+    _logger.info(
+        'Deactivating $runtimeType. (This is usually called right before dispose)');
     _controller.onDeactivated();
     super.deactivate();
   }

--- a/lib/src/view.dart
+++ b/lib/src/view.dart
@@ -144,31 +144,26 @@ abstract class ViewState<Page extends View, Con extends Controller>
     _logger = Logger('${runtimeType}');
   }
 
-  /// Should be used when need to perform some action on [initState] life cycle. [Controller] is injected on parameters.
-  /// [super.initViewState] should be called before the actions you need to perform.
-  ///
-  /// ```dart
-  /// void initViewState(CounterController controller) {
-  ///   super.initViewState(controller);
-  ///   controller.initializeCounter();
-  /// }
-  /// ```
   @mustCallSuper
+  @Deprecated('''To attribute the correct responsabilities to each class, all view lifecycles must be controlled by 
+    correct `Controller`.
+    
+    To achieve correct use of `ViewState.initState`, please check out `Controller.onInitState` method.
+    
+    This method will be removed in next release.
+  ''')
   void initViewState(Con controller) {
     _logger.info('Initializing state of $runtimeType');
   }
 
-  /// Should be used when need to perform some action on [didChangeDependencies] life cycle. [Controller] is injected on parameters.
-  /// [super.initViewState] should be called before the actions you need to perform. Like [didChangeDependencies], you can safely perform
-  /// actions that depends on [BuildContext] here.
-  ///
-  /// ```dart
-  /// void didChangeViewDependencies(CounterController controller) {
-  ///   super.didChangeViewDependencies(controller);
-  ///   controller.updateCounterOnDependencies();
-  /// }
-  /// ```
   @mustCallSuper
+  @Deprecated('''To attribute the correct responsabilities to each class, all view lifecycles must be controlled by 
+    correct `Controller`.
+    
+    To achieve correct use of `ViewState.didChangeDependencies`, please check out `Controller.onDidChangeDependencies` method.
+    
+    This method will be removed in next release.
+  ''')
   void didChangeViewDependencies(Con controller) {
     _logger.info('didChangeDependencies triggered on $runtimeType');
   }
@@ -181,6 +176,7 @@ abstract class ViewState<Page extends View, Con extends Controller>
       widget.routeObserver.subscribe(_controller, ModalRoute.of(context));
     }
 
+    _controller.onDidChangeDependencies();
     didChangeViewDependencies(_controller);
     super.didChangeDependencies();
   }
@@ -188,6 +184,7 @@ abstract class ViewState<Page extends View, Con extends Controller>
   @override
   @nonVirtual
   void initState() {
+    _controller.onInitState();
     initViewState(_controller);
     super.initState();
   }
@@ -196,6 +193,22 @@ abstract class ViewState<Page extends View, Con extends Controller>
   @nonVirtual
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<Con>.value(value: _controller, child: view);
+  }
+
+  @override
+  @mustCallSuper
+  void deactivate() {
+    _logger.info('Deactivating $runtimeType. (This is usually called right before dispose)');
+    _controller.onDeactivated();
+    super.deactivate();
+  }
+
+  @override
+  @mustCallSuper
+  void reassemble() {
+    _logger.info('Reassembling $runtimeType.');
+    _controller.onReassembled();
+    super.reassemble();
   }
 
   @override

--- a/lib/src/view.dart
+++ b/lib/src/view.dart
@@ -181,6 +181,7 @@ abstract class ViewState<Page extends View, Con extends Controller>
       widget.routeObserver.subscribe(_controller, ModalRoute.of(context));
     }
 
+    didChangeViewDependencies(_controller);
     super.didChangeDependencies();
   }
 

--- a/lib/src/view.dart
+++ b/lib/src/view.dart
@@ -202,7 +202,7 @@ abstract class ViewState<Page extends View, Con extends Controller>
   @mustCallSuper
   void dispose() {
     _logger.info('Disposing $runtimeType.');
-    _controller.onDisposed(context);
+    _controller.onDisposed();
     super.dispose();
   }
 }

--- a/lib/src/view.dart
+++ b/lib/src/view.dart
@@ -152,9 +152,7 @@ abstract class ViewState<Page extends View, Con extends Controller>
     
     This method will be removed in next release.
   ''')
-  void initViewState(Con controller) {
-    _logger.info('Initializing state of $runtimeType');
-  }
+  void initViewState(Con controller) {}
 
   @mustCallSuper
   @Deprecated('''To attribute the correct responsabilities to each class, all view lifecycles must be controlled by 
@@ -164,9 +162,7 @@ abstract class ViewState<Page extends View, Con extends Controller>
     
     This method will be removed in next release.
   ''')
-  void didChangeViewDependencies(Con controller) {
-    _logger.info('didChangeDependencies triggered on $runtimeType');
-  }
+  void didChangeViewDependencies(Con controller) {}
 
   @override
   @mustCallSuper
@@ -176,7 +172,9 @@ abstract class ViewState<Page extends View, Con extends Controller>
       widget.routeObserver.subscribe(_controller, ModalRoute.of(context));
     }
 
+    _logger.info('didChangeDependencies triggered on $runtimeType');
     _controller.onDidChangeDependencies();
+    // TODO: Remove in next release
     didChangeViewDependencies(_controller);
     super.didChangeDependencies();
   }
@@ -184,7 +182,9 @@ abstract class ViewState<Page extends View, Con extends Controller>
   @override
   @nonVirtual
   void initState() {
+    _logger.info('Initializing state of $runtimeType');
     _controller.onInitState();
+    // TODO: Remove in next release
     initViewState(_controller);
     super.initState();
   }

--- a/test/controller_test.dart
+++ b/test/controller_test.dart
@@ -7,6 +7,9 @@ GlobalKey snackBar = GlobalKey();
 GlobalKey inc = GlobalKey();
 
 void main() {
+  int initialCounter;
+  BuildContext widgetContext;
+
   var numberOfWidgetBuilds = 0;
   var numberOfUncontrolledWidgetBuilds = 0;
   var numberOfControlledWidgetBuilds = 0;
@@ -18,10 +21,9 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: CounterPage(
         // Will be triggered right after initViewState
-        onWidgetChangeDependencies:
-            (BuildContext context, CounterController controller) {
-          expect(controller.counter, equals(0));
-          expect(context, isNotNull);
+        onWidgetChangeDependencies: (context, CounterController controller) {
+          initialCounter = controller.counter;
+          widgetContext = context;
         },
         onWidgetBuild: () {
           numberOfWidgetBuilds++;
@@ -35,6 +37,8 @@ void main() {
       ),
     ));
 
+    expect(initialCounter, equals(0));
+    expect(widgetContext, isNotNull);
     // Create our Finders
     var counterFinder = find.text('0');
     expect(counterFinder, findsOneWidget);

--- a/test/controller_test.dart
+++ b/test/controller_test.dart
@@ -87,11 +87,10 @@ class CounterController extends Controller {
 
   int counter;
 
-  CounterController({
-     this.onViewDidChangeDependencies,
-     this.onViewInitState,
-     this.onViewDeactivated
-  });
+  CounterController(
+      {this.onViewDidChangeDependencies,
+      this.onViewInitState,
+      this.onViewDeactivated});
 
   void increment() {
     counter++;
@@ -131,12 +130,11 @@ class CounterPage extends View {
   final Function onControlledWidgetBuild;
   final Function onUncontrolledWidgetBuild;
 
-  CounterPage({
-    this.onWidgetBuild,
-    this.onUncontrolledWidgetBuild,
-    this.onControlledWidgetBuild,
-    this.controller
-  });
+  CounterPage(
+      {this.onWidgetBuild,
+      this.onUncontrolledWidgetBuild,
+      this.onControlledWidgetBuild,
+      this.controller});
 
   @override
   State<StatefulWidget> createState() => CounterState(controller: controller);


### PR DESCRIPTION
## Description

<!-- 
  Replace this paragraph with a description of what this PR is doing.
-->

*The motivation of this PR is to correct delegate the control of `View` life cycle to controller, to
ensure the correct usage of chain of responsability. With those changes, the usage of `didChangeViewDependencies` and `initViewState` were deprecated to be removed in next release, and was
created some life cycle controllers on `Controller` to correct control view states*

*It was created:*

- `onDeactivated`
- `onReassembled`
- `onInitState`
- `onDidChangeDependencies`

*To ensure correct control of view life cycles and avoid the need of inject controller inside view unecessarely*

*Also, due to unsafe usages of uncorrect context. It was removed injection of `BuildContext` on `onDisposed` life cycle. We suggest the usage of what is need the context on `onDeactivated` life cycle, that occurs right before `dispose` and presents a more safe usage of context*

## Developer checklist

<!-- 
  Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). 
  This will ensure a smooth and quick review process.
-->

- [x] All github actions are passing.

## For reviewers

All PR's needs at least one reviewer to be merged.

Before merge this PR confirm that it meets all requirements listed below:

- The PR has good quality code and has tests (if is the case)
- This PR is not checked with WIP on title