### PR TITLE
[Minor Candidate][Responsive View] - Changed methods from ResponsiveViewState and removed deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [4.1.0] - Tuesday, January 5th, 2021
+### What's new
+- Created `mobileView` on `ResponsiveViewState` to allow correct usage of `globalKey` and improve coherence with parent class
+- Created `tabletView` on `ResponsiveViewState` to allow correct usage of `globalKey` and improve coherence with parent class
+- Created `desktopView` on `ResponsiveViewState` to allow correct usage of `globalKey` and improve coherence with parent class
+- Created `watchView` on `ResponsiveViewState` to allow correct usage of `globalKey` and improve coherence with parent class
+
+### Breaking changes
+- Removed deprecated methods from view
+- Removed deprecated methods from controller
+- Removed `mobileBuilder` from `ResponsiveViewState`
+- Removed `tabletBuilder` from `ResponsiveViewState`
+- Removed `desktopBuilder` from `ResponsiveViewState`
+- Removed `watchBuilder` from `ResponsiveViewState`
+
 ## [4.0.4] - Thursday, December 17th, 2020
 - Removed `BuildContext` injection from `Controller.onDisposed` life cycle to avoid unsafe usages of dead context
 - Created `Controller.onInitState` to correct control `View.initState` life cycle.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add this to your package's pubspec.yaml file:
 ```yaml
 
 dependencies:
-  flutter_clean_architecture: ^4.0.4
+  flutter_clean_architecture: ^4.1.0
 
 ```
 
@@ -95,8 +95,11 @@ Since `App` is the presentation layer of the application, it is the most framewo
     * **void onInActive()**
     * **void onPaused()** 
     * **void onResumed()** 
-    * **void onDetatched()**
-    * **void onDidPop()**
+    * **void onDetached()**
+    * **void onDisposed()**
+    * **void onReassembled()**
+    * **void onDidChangeDependencies()**
+    * **void onInitState()**
     * etc..
   * Also, every `Controller` **has** to implement **initListeners()** that initializes the listeners for the `Presenter` for consistency.
   * The `Controller` **has-a** `Presenter`. The `Controller` will pass the `Repository` to the `Presenter`, which it communicate later with the `Usecase`. The `Controller` will specify what listeners the `Presenter` should call for all success and error events as mentioned previously. Only the `Controller` is allowed to obtain instances of a `Repository` from the `Data` or `Device` module in the outermost layer.
@@ -210,10 +213,9 @@ class CounterState extends ViewState<CounterPage, CounterController> {
      CounterState() : super(CounterController());
 
      @override
-     Widget buildPage() {
-       return MaterialApp(
-         title: 'Flutter Demo',
-      home: Scaffold(
+     Widget get view => MaterialApp(
+        title: 'Flutter Demo',
+        home: Scaffold(
         key: globalKey, // using the built-in global key of the `View` for the scaffold or any other
                         // widget provides the controller with a way to access them via getContext(), getState(), getStateKey()
         body: Column(
@@ -237,7 +239,6 @@ class CounterState extends ViewState<CounterPage, CounterController> {
         ),
       ),
     );
-  }
 }
 ```
 ##### Responsive view state
@@ -271,55 +272,49 @@ class CounterState extends ResponsiveViewState<CounterPage, CounterController> {
      }
  
      @override
-     ViewBuilder mobileBuilder = (BuildContext context) {
-       return AppScaffold(
-          child: Column(
-              children: <Widget>[
-                // you can refresh manually inside the controller
-                // using refreshUI()
-                ControlledWidgetBuilder<CounterController>(
-                  builder: (context, controller) {
-                    return Text('Counter on mobile view ${controller.counter.toString()}');
-                  }
-                ),
-              ],
-            )
-       );
-     };
-
-     @override
-     ViewBuilder tabletBuilder = (BuildContext context) {
-       return AppScaffold(
+     ViewBuilder get mobileView => AppScaffold(
          child: Column(
              children: <Widget>[
                // you can refresh manually inside the controller
                // using refreshUI()
                ControlledWidgetBuilder<CounterController>(
                  builder: (context, controller) {
-                   return Text('Counter on tablet view ${controller.counter.toString()}');
+                   return Text('Counter on mobile view ${controller.counter.toString()}');
                  }
                ),
              ],
            )
-       );
-     };
+      );
 
      @override
-     ViewBuilder desktopBuilder = (BuildContext context) {
-       return AppScaffold(
-         child: Row(
-             children: <Widget>[
-               // you can refresh manually inside the controller
-               // using refreshUI()
-               ControlledWidgetBuilder<CounterController>(
-                 builder: (context, controller) {
-                   return Text('Counter on desktop view ${controller.counter.toString()}');
-                 }
-               ),
-             ],
-           )
-       );
-     };
+     ViewBuilder get tabletBuilder => AppScaffold(
+       child: Column(
+           children: <Widget>[
+             // you can refresh manually inside the controller
+             // using refreshUI()
+             ControlledWidgetBuilder<CounterController>(
+               builder: (context, controller) {
+                 return Text('Counter on tablet view ${controller.counter.toString()}');
+               }
+             ),
+           ],
+         )
+     );
+
+     @override
+     ViewBuilder get desktopBuilder => AppScaffold(
+        child: Row(
+            children: <Widget>[
+              // you can refresh manually inside the controller
+              // using refreshUI()
+              ControlledWidgetBuilder<CounterController>(
+                builder: (context, controller) {
+                  return Text('Counter on desktop view ${controller.counter.toString()}');
+                }
+              ),
+            ],
+          )
+      );
 }
 ```
 
@@ -663,4 +658,5 @@ class User {
 Checkout a small example [here](./example/) and a full application built [here](https://github.com/ShadyBoukhary/Axion-Technologies-HnH).
 
 ## Authors
-**Shady Boukhary** 
+**[Shady Boukhary](https://github.com/ShadyBoukhary)** 
+**[Rafael Monteiro](https://github.com/rafaelcmm)**

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.0.3"
+    version: "4.0.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.0.4"
+    version: "4.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -140,10 +140,7 @@ abstract class Controller
   }
 
   @override
-  @mustCallSuper
-  @visibleForOverriding
-  @Deprecated(
-      'Please use `onDisposed` to achieve correct behavior. Will be removed in the next release.')
+  @nonVirtual
   void dispose() {
     _isMounted = false;
     logger.info('Disposing ${runtimeType}');

--- a/lib/src/view.dart
+++ b/lib/src/view.dart
@@ -60,33 +60,32 @@ abstract class ResponsiveViewState<Page extends View, Con extends Controller>
     extends ViewState<Page, Con> {
   ResponsiveViewState(Con controller) : super(controller);
 
-  /// Abstract builder to be implemented by the developer which will build on [Watch ViewPort].
-  ///   /// The default breakpoint value is less than [300]
-  ViewBuilder watchBuilder;
+  /// To be implemented by the developer which will build on [Watch ViewPort].
+  /// The default breakpoint value is less than [300]
+  Widget get watchView;
 
-  /// Abstract builder to be implemented by the developer which will build on [Mobile ViewPort].
-  /// The default breakpoint value is more than [300]
-  ViewBuilder mobileBuilder;
+  /// To be implemented by the developer which will build on [Mobile ViewPort].
+  /// The default breakpoint value is more than [375]
+  Widget get mobileView;
 
-  /// Abstract builder to be implemented by the developer which will build on [Tablet/Pad ViewPort].
-  ///   /// The default breakpoint value is [600]
-  ViewBuilder tabletBuilder;
+  /// To be implemented by the developer which will build on [Tablet/Pad ViewPort].
+  /// The default breakpoint value is [600]
+  Widget get tabletView;
 
-  /// Abstract builder to be implemented by the developer which will build on [Desktop ViewPort].
-  ///   /// The default breakpoint value is [950]
-  ViewBuilder desktopBuilder;
+  /// To be implemented by the developer which will build on [Desktop ViewPort].
+  /// The default breakpoint value is [950]
+  Widget get desktopView;
 
-  /// This turns buildPage into an implicit method that build according to the given builds methods: [MOBILE], [TABLET], [DESKTOP] and [WATCH].
+  /// This turns view into an implicit method that build according to the given builds methods: [MOBILE], [TABLET], [DESKTOP] and [WATCH].
   /// The Default Viewport is [MOBILE]. When [TABLET] or [DESKTOP] builds are null, [MOBILE] viewport will be called.
-
   @override
   @nonVirtual
   Widget get view {
     return ScreenTypeLayout.builder(
-      mobile: mobileBuilder,
-      tablet: tabletBuilder,
-      desktop: desktopBuilder,
-      watch: watchBuilder,
+      mobile: (_) => mobileView,
+      tablet: (_) => tabletView,
+      desktop: (_) => desktopView,
+      watch: (_) => watchView,
     );
   }
 }
@@ -144,28 +143,6 @@ abstract class ViewState<Page extends View, Con extends Controller>
     _logger = Logger('${runtimeType}');
   }
 
-  @mustCallSuper
-  @Deprecated(
-      '''To attribute the correct responsabilities to each class, all view lifecycles must be controlled by 
-    correct `Controller`.
-    
-    To achieve correct use of `ViewState.initState`, please check out `Controller.onInitState` method.
-    
-    This method will be removed in next release.
-  ''')
-  void initViewState(Con controller) {}
-
-  @mustCallSuper
-  @Deprecated(
-      '''To attribute the correct responsabilities to each class, all view lifecycles must be controlled by 
-    correct `Controller`.
-    
-    To achieve correct use of `ViewState.didChangeDependencies`, please check out `Controller.onDidChangeDependencies` method.
-    
-    This method will be removed in next release.
-  ''')
-  void didChangeViewDependencies(Con controller) {}
-
   @override
   @mustCallSuper
   void didChangeDependencies() {
@@ -176,8 +153,6 @@ abstract class ViewState<Page extends View, Con extends Controller>
 
     _logger.info('didChangeDependencies triggered on $runtimeType');
     _controller.onDidChangeDependencies();
-    // TODO: Remove in next release
-    didChangeViewDependencies(_controller);
     super.didChangeDependencies();
   }
 
@@ -186,8 +161,6 @@ abstract class ViewState<Page extends View, Con extends Controller>
   void initState() {
     _logger.info('Initializing state of $runtimeType');
     _controller.onInitState();
-    // TODO: Remove in next release
-    initViewState(_controller);
     super.initState();
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_clean_architecture
 description: A Flutter package that implements the Clean Architecture by Uncle Bob in Flutter. It provides Views, Controllers, Presenters, Observers, and UseCases.
-version: 4.0.4
+version: 4.1.0
 author: Shady Boukhary <sb199898.sb@gmail.com>
 homepage: https://github.com/ShadyBoukhary/flutter_clean_architecture
 

--- a/test/responsive_view_test.dart
+++ b/test/responsive_view_test.dart
@@ -150,16 +150,16 @@ class _TestPageState extends ResponsiveViewState<TestPage, TestController> {
   _TestPageState(TestController controller) : super(controller);
 
   @override
-  Widget get desktopView => Container(child: Center(child: Text('Desktop')));
+  Widget get desktopView => Container(key: globalKey, child: Center(child: Text('Desktop')));
 
   @override
-  Widget get mobileView => Container(child: Center(child: Text('Mobile')));
+  Widget get mobileView => Container(key: globalKey, child: Center(child: Text('Mobile')));
 
   @override
-  Widget get tabletView => Container(child: Center(child: Text('Tablet')));
+  Widget get tabletView => Container(key: globalKey, child: Center(child: Text('Tablet')));
 
   @override
-  Widget get watchView => Container(child: Center(child: Text('Watch')));
+  Widget get watchView => Container(key: globalKey, child: Center(child: Text('Watch')));
 }
 
 /// This is a snippet to change the default value of test flutter emulator size.

--- a/test/responsive_view_test.dart
+++ b/test/responsive_view_test.dart
@@ -3,26 +3,30 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_clean_architecture/flutter_clean_architecture.dart';
 
 void main() {
+  var stateInitialized = false;
+  var viewDidChangeViewDependenciesTriggered = false;
+  var stateDeactivated = false;
+
+  Widget page;
+  TestController controller;
+
+  setUp(() {
+    controller = TestController(
+      onViewDeactivated: () {
+        stateDeactivated = true;
+      },
+      onViewDidChangeDependencies: () {
+        viewDidChangeViewDependenciesTriggered = true;
+      },
+      onViewInitState: () {
+        stateInitialized = true;
+      },
+    );
+    page = TestPage(controller: controller);
+  });
+
   testWidgets('Run TestPage | Mobile viewport then resizes',
       (WidgetTester tester) async {
-    var stateInitialized = false;
-    var viewDidChangeViewDependenciesTriggered = false;
-    var stateDeactivated = false;
-
-    final page = TestPage(
-      controller: TestController(
-        onViewDeactivated: () {
-          stateDeactivated = true;
-        },
-        onViewDidChangeDependencies: () {
-          viewDidChangeViewDependenciesTriggered = true;
-        },
-        onViewInitState: () {
-          stateInitialized = true;
-        },
-      ),
-    );
-
     await tester.setScreenSize(width: 540, height: 540);
 
     await tester.pumpWidget(MaterialApp(home: page));
@@ -54,9 +58,6 @@ void main() {
   });
 
   testWidgets('Run TestPage | Mobile Viewport', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    final page = TestPage();
-
     await tester.setScreenSize(width: 540, height: 540);
 
     await tester.pumpWidget(MaterialApp(home: page));
@@ -71,9 +72,6 @@ void main() {
   });
 
   testWidgets('Run TestPage | Tablet Viewport', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    final page = TestPage();
-
     await tester.setScreenSize(width: 700, height: 600);
 
     await tester
@@ -86,9 +84,6 @@ void main() {
   });
 
   testWidgets('Run TestPage | Desktop Viewport', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    final page = TestPage();
-
     await tester.setScreenSize(width: 1024, height: 1024);
 
     await tester
@@ -101,9 +96,6 @@ void main() {
   });
 
   testWidgets('Run TestPage | Watch Viewport', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    final page = TestPage();
-
     await tester.setScreenSize(width: 250, height: 250);
 
     await tester
@@ -123,8 +115,8 @@ class TestController extends Controller {
 
   TestController(
       {this.onViewDidChangeDependencies,
-        this.onViewInitState,
-        this.onViewDeactivated});
+      this.onViewInitState,
+      this.onViewDeactivated});
 
   @override
   void initListeners() {}
@@ -158,24 +150,16 @@ class _TestPageState extends ResponsiveViewState<TestPage, TestController> {
   _TestPageState(TestController controller) : super(controller);
 
   @override
-  ViewBuilder desktopBuilder = (BuildContext context) {
-    return Container(child: Center(child: Text('Desktop')));
-  };
+  Widget get desktopView => Container(child: Center(child: Text('Desktop')));
 
   @override
-  ViewBuilder mobileBuilder = (BuildContext context) {
-    return Container(child: Center(child: Text('Mobile')));
-  };
+  Widget get mobileView => Container(child: Center(child: Text('Mobile')));
 
   @override
-  ViewBuilder tabletBuilder = (BuildContext context) {
-    return Container(child: Center(child: Text('Tablet')));
-  };
+  Widget get tabletView => Container(child: Center(child: Text('Tablet')));
 
   @override
-  ViewBuilder watchBuilder = (BuildContext context) {
-    return Container(child: Center(child: Text('Watch')));
-  };
+  Widget get watchView => Container(child: Center(child: Text('Watch')));
 }
 
 /// This is a snippet to change the default value of test flutter emulator size.

--- a/test/responsive_view_test.dart
+++ b/test/responsive_view_test.dart
@@ -150,16 +150,20 @@ class _TestPageState extends ResponsiveViewState<TestPage, TestController> {
   _TestPageState(TestController controller) : super(controller);
 
   @override
-  Widget get desktopView => Container(key: globalKey, child: Center(child: Text('Desktop')));
+  Widget get desktopView =>
+      Container(key: globalKey, child: Center(child: Text('Desktop')));
 
   @override
-  Widget get mobileView => Container(key: globalKey, child: Center(child: Text('Mobile')));
+  Widget get mobileView =>
+      Container(key: globalKey, child: Center(child: Text('Mobile')));
 
   @override
-  Widget get tabletView => Container(key: globalKey, child: Center(child: Text('Tablet')));
+  Widget get tabletView =>
+      Container(key: globalKey, child: Center(child: Text('Tablet')));
 
   @override
-  Widget get watchView => Container(key: globalKey, child: Center(child: Text('Watch')));
+  Widget get watchView =>
+      Container(key: globalKey, child: Center(child: Text('Watch')));
 }
 
 /// This is a snippet to change the default value of test flutter emulator size.


### PR DESCRIPTION
## Description

<!-- 
  Replace this paragraph with a description of what this PR is doing.
-->

This PR has the objective of:

- Change builder methods on `ResponsiveViewState` to an approach that allows the free usage of `globalKey` inside the widgets, and to be more coherent with parent class (If `ViewState` implements a `view`, so the `ResponsiveViewState` should implement view getters.
- Remove deprecated methods (breaking changes)

Since both changes are breaking changes, I decided to bump a minor version, if you agree with it.


## Developer checklist

<!-- 
  Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). 
  This will ensure a smooth and quick review process.
-->

- [x] All github actions are passing.

## For reviewers

All PR's needs at least one reviewer to be merged.

Before merge this PR confirm that it meets all requirements listed below:

- The PR has good quality code and has tests (if is the case)
- This PR is not checked with WIP on title